### PR TITLE
add vsync by default to XFCE

### DIFF
--- a/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml
+++ b/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml
@@ -53,6 +53,7 @@
     <property name="snap_to_border" type="bool" value="true"/>
     <property name="snap_to_windows" type="bool" value="false"/>
     <property name="snap_width" type="int" value="10"/>
+    <property name="sync_to_vblank" type="bool" value="true"/>
     <property name="theme" type="string" value="Stoneage"/>
     <property name="title_alignment" type="string" value="center"/>
     <property name="title_font" type="string" value="Sans Bold 9"/>


### PR DESCRIPTION
Adding vsync to XFCE fixes flickering in intel GPUs